### PR TITLE
Fix/settings oauth

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -106,16 +106,16 @@
         },
         {
             "name": "onpayio/php-sdk",
-            "version": "1.0.3",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/onpayio/php-sdk.git",
-                "reference": "53d30458abf3635c069447b768a021d45d425613"
+                "reference": "bac5d493800dcebfd4a4b8707b4bc9ea1e09cf5a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/onpayio/php-sdk/zipball/53d30458abf3635c069447b768a021d45d425613",
-                "reference": "53d30458abf3635c069447b768a021d45d425613",
+                "url": "https://api.github.com/repos/onpayio/php-sdk/zipball/bac5d493800dcebfd4a4b8707b4bc9ea1e09cf5a",
+                "reference": "bac5d493800dcebfd4a4b8707b4bc9ea1e09cf5a",
                 "shasum": ""
             },
             "require": {
@@ -134,7 +134,7 @@
             ],
             "description": "PHP SDK for OnPay.io API",
             "homepage": "https://github.com/onpayio/php-sdk",
-            "time": "2019-10-18T07:54:33+00:00"
+            "time": "2020-02-26T07:58:29+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",

--- a/woocommerce-onpay.php
+++ b/woocommerce-onpay.php
@@ -85,7 +85,6 @@ function init_onpay() {
             $this->has_fields   = false;
             $this->method_description = __('Receive payments with cards and more through OnPay.io', 'wc-onpay');
 
-            $this->init_form_fields();
             $this->init_settings();
 
             if (is_admin()) {
@@ -233,6 +232,8 @@ function init_onpay() {
          * Method that renders payment gateway settings page in woocommerce
          */
         public function admin_options() {
+            $this->init_form_fields();
+
             $onpayApi = $this->get_onpay_client(true);
 
             $this->handle_oauth_callback();
@@ -277,6 +278,13 @@ function init_onpay() {
             
             echo ent2ncr($html);
         }
+
+        public function process_admin_options() {
+            $this->init_form_fields();
+
+            parent::process_admin_options();
+        }
+
 
         /**
          * Method for setting meta boxes in admin


### PR DESCRIPTION
Fixing issues with the settings page.
- Only initialize the settings fields on the settings page
- Updated the OnPay SDK, with the latest version that resolves a issue with invalid oauth tokens