### PR TITLE
Feature/dependency liberation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Confirmed working on Wordpress 5.5 and WooCommerce 4.4.1
+- Added prefix to dependency namespaces during build, to prevent any overlap with dependency versions from other plugins that might be installed
 
 ## [1.0.6] - 2020-06-18
 - Confirmed working on Wordpress 5.4.2 and WooCommerce 4.2.0

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ The plugin adds the following functionality to WooCommerce:
 - Management of transaction on order pages in backoffice.
 
 The plugin is tested and confirmed working on 
-- Wordpress 5.3 to 5.4.2
-- WooCommerce 3.8.1 to 4.2.0
+- Wordpress 5.3 to 5.5
+- WooCommerce 3.8.1 to 4.4.1
 
 ## Usage
 1. Install plugin as any other Wordpress plugin.

--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@
 Contributors: onpayio
 Tags: onpay, gateway, payment, payment gateway, woocommerce, psp
 Requires at least: 5.3
-Tested up to: 5.4.2
+Tested up to: 5.5
 Requires PHP: 5.6
 Stable tag: 1.0.6
 License: MIT

--- a/build.sh
+++ b/build.sh
@@ -18,17 +18,41 @@ rm composer-setup.php
 
 # Remove vendor directory
 rm -rf vendor
+rm -rf build
 
 # Run composer install
 php composer.phar install
 
+# Require and run php-scoper
+php composer.phar global require humbug/php-scoper
+COMPOSER_BIN_DIR="$(composer global config bin-dir --absolute)"
+"$COMPOSER_BIN_DIR"/php-scoper add-prefix
+
+# Dump composer autoload for build folder
+php composer.phar dump-autoload --working-dir build --classmap-authoritative
+
 # Remove composer
 rm composer.phar
 
-# Zip contents of folder to onpay folder in a zip file
+# Remove existing build zip file
 rm woocommerce-onpay.zip
+
+# Rsync contents of folder to new directory that we will use for the build
 rsync -Rr ./* ./woocommerce-onpay
+
+# Remove directories and files from newly created directory, that we won't need in final build
+rm -rf ./woocommerce-onpay/vendor
+rm ./woocommerce-onpay/build.sh
+rm ./woocommerce-onpay/composer.json
+rm ./woocommerce-onpay/composer.lock
+
+# Replace require file with build version
+rm ./woocommerce-onpay/require.php
+mv ./woocommerce-onpay/require_build.php ./woocommerce-onpay/require.php
+
+# Zip contents of newly created directory
 zip -r woocommerce-onpay.zip ./woocommerce-onpay
 
 # Clean up
 rm -rf woocommerce-onpay
+rm -rf build

--- a/require.php
+++ b/require.php
@@ -1,0 +1,2 @@
+<?php
+    require_once __DIR__ . '/vendor/autoload.php';

--- a/require_build.php
+++ b/require_build.php
@@ -1,0 +1,47 @@
+<?php
+    require_once __DIR__ . '/build/vendor/scoper-autoload.php';
+
+    /**
+     * Here we'll map out classes used directly in OnPay woocommerce plugin or helper classes.
+     * This way we'll keep class/namespace references the same in plugin code, regardless of whether plugin is built or not.
+     */
+
+    /**
+     * OnPay SDK classes
+     */
+    class_alias('WoocommerceOnpay\OnPay\OnPayAPI', 'OnPay\OnPayAPI');
+
+    class_alias('WoocommerceOnpay\OnPay\TokenStorageInterface', 'OnPay\TokenStorageInterface');
+
+    class_alias('WoocommerceOnpay\OnPay\API\GatewayService', 'OnPay\API\GatewayService');
+    class_alias('WoocommerceOnpay\OnPay\API\PaymentWindow', 'OnPay\API\PaymentWindow');
+    class_alias('WoocommerceOnpay\OnPay\API\SubscriptionService', 'OnPay\API\SubscriptionService');
+    class_alias('WoocommerceOnpay\OnPay\API\TransactionService', 'OnPay\API\TransactionService');
+
+    class_alias('WoocommerceOnpay\OnPay\API\Exception\ApiException', 'OnPay\API\Exception\ApiException');
+    class_alias('WoocommerceOnpay\OnPay\API\Exception\ConnectionException', 'OnPay\API\Exception\ConnectionException');
+    class_alias('WoocommerceOnpay\OnPay\API\Exception\TokenException', 'OnPay\API\Exception\TokenException');
+
+    class_alias('WoocommerceOnpay\OnPay\API\Gateway\Information', 'OnPay\API\Gateway\Information');
+    class_alias('WoocommerceOnpay\OnPay\API\Gateway\PaymentWindowDesignCollection', 'OnPay\API\Gateway\PaymentWindowDesignCollection');
+    class_alias('WoocommerceOnpay\OnPay\API\Gateway\PaymentWindowIntegrationSettings', 'OnPay\API\Gateway\PaymentWindowIntegrationSettings');
+    class_alias('WoocommerceOnpay\OnPay\API\Gateway\SimplePaymentWindowDesign', 'OnPay\API\Gateway\SimplePaymentWindowDesign');
+
+    class_alias('WoocommerceOnpay\OnPay\API\Subscription\DetailedSubscription', 'OnPay\API\Subscription\DetailedSubscription');
+    class_alias('WoocommerceOnpay\OnPay\API\Subscription\SimpleSubscription', 'OnPay\API\Subscription\SimpleSubscription');
+    class_alias('WoocommerceOnpay\OnPay\API\Subscription\SubscriptionCollection', 'OnPay\API\Subscription\SubscriptionCollection');
+    class_alias('WoocommerceOnpay\OnPay\API\Subscription\SubscriptionHistory', 'OnPay\API\Subscription\SubscriptionHistory');
+
+    class_alias('WoocommerceOnpay\OnPay\API\Transaction\DetailedTransaction', 'OnPay\API\Transaction\DetailedTransaction');
+    class_alias('WoocommerceOnpay\OnPay\API\Transaction\SimpleTransaction', 'OnPay\API\Transaction\SimpleTransaction');
+    class_alias('WoocommerceOnpay\OnPay\API\Transaction\TransactionCollection', 'OnPay\API\Transaction\TransactionCollection');
+    class_alias('WoocommerceOnpay\OnPay\API\Transaction\TransactionHistory', 'OnPay\API\Transaction\TransactionHistory');
+
+    class_alias('WoocommerceOnpay\OnPay\API\Util\Converter', 'OnPay\API\Util\Converter');
+    class_alias('WoocommerceOnpay\OnPay\API\Util\Link', 'OnPay\API\Util\Link');
+    class_alias('WoocommerceOnpay\OnPay\API\Util\Pagination', 'OnPay\API\Util\Pagination');
+
+    /**
+     * Other Classes
+     */
+    class_alias('WoocommerceOnpay\Alcohol\ISO4217', 'Alcohol\ISO4217');

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Isolated\Symfony\Component\Finder\Finder;
+
+return [
+    'prefix' => 'WoocommerceOnpay',
+    'finders' => [
+        Finder::create()
+            ->files()
+            ->ignoreVCS(true)
+            ->in('vendor'),
+        Finder::create()->append([
+            'composer.json',
+        ]),
+    ],
+    'whitelist-global-constants' => false,
+    'whitelist-global-classes' => false,
+    'whitelist-global-functions' => false,
+];

--- a/woocommerce-onpay.php
+++ b/woocommerce-onpay.php
@@ -37,7 +37,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit; // Exit if accessed directly
 }
 
-require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/require.php';
 require_once __DIR__ . '/classes/currency-helper.php';
 require_once __DIR__ . '/classes/token-storage.php';
 


### PR DESCRIPTION
- Added prefix to dependency namespaces during build, to prevent any overlap with dependency versions from other plugins that might be installed

- Confirmed working on Wordpress 5.5 and WooCommerce 4.4.1