### PR TITLE
Fix bug with invalid token crashing whole site

### DIFF
--- a/woocommerce-onpay.php
+++ b/woocommerce-onpay.php
@@ -555,22 +555,6 @@ function init_onpay() {
         }
 
         /**
-         * @var \OnPay\OnPayAPI $onpayClient
-         * @return boolean
-         */
-        private function is_onpay_client_connected($onpayClient) {
-            if (!$onpayClient instanceof \OnPay\OnPayAPI) {
-                return false;
-            }
-            try {
-                $onpayClient->ping();
-            } catch (OnPay\API\Exception\ConnectionException $exception) {
-                return false;
-            }
-            return true;
-        }
-
-        /**
          * Returns instance of PaymentWindow based on WC_Order
          */
         private function get_payment_window($order) {

--- a/woocommerce-onpay.php
+++ b/woocommerce-onpay.php
@@ -104,9 +104,6 @@ function init_onpay() {
          */
         public function is_available() {
             $onpayApi = $this->get_onpay_client();
-            if (!$this->is_onpay_client_connected($onpayApi) || !$onpayApi->isAuthorized()) {
-                return false;
-            }
 
             if ($this->get_option(self::SETTING_ONPAY_EXTRA_PAYMENTS_CARD) !== 'yes' &&
                 $this->get_option(self::SETTING_ONPAY_EXTRA_PAYMENTS_MOBILEPAY) !== 'yes' &&


### PR DESCRIPTION
We should *never* call the API just to complete a normal checkout, and by removing that function this crash should not happen anymore.
The rest of the calls has nice catch'es around, incase the token is invalid.