### PR TITLE
Added specific styling for payment method logos, for themes that dont…

### DIFF
--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -26,6 +26,19 @@
     display: block;
 }
 
+/** 
+ * Adds styling to card logos when theme does not apply,
+ * but is overridden by the default selector '#payment .payment_methods li img' 
+ * provided by the WooCommerce storefront theme,
+ * and is overridden by the default selector '.wc_payment_method > label:first-of-type img'
+ * provided by the Wordpress Twenty Twenty-One theme.
+ */
+.payment_method_onpay_card img,
+.payment_method_onpay_mobilepay img,
+.payment_method_onpay_viabill img {
+    max-height: 26px;
+}
+
 #payment .payment_methods .onpay_card_logos > img {
     float: unset;
     display:inline-block;


### PR DESCRIPTION
… support woocommerce payment_method styling

before:
![Screenshot_2021-01-18_16-24-39](https://user-images.githubusercontent.com/4209221/104933912-c8e92600-59a9-11eb-92f5-9df4fdc7b539.png)

after:
![Screenshot_2021-01-18_16-24-51](https://user-images.githubusercontent.com/4209221/104933914-c981bc80-59a9-11eb-98aa-ef5a342d8a0c.png)
