### PR TITLE
DK1ONP1-5016 - Information Exposure - Server Error Message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Change onboarding and update language files
 - Improve subscription renewal handling for OnPay connection issues
+- Prevent exception message disclosure in error output
 
 ## [1.0.50] - 2026-03-03
 - Fix Blocks checkout error notice persistence after declined payment

--- a/classes/abstract-gateway.php
+++ b/classes/abstract-gateway.php
@@ -69,7 +69,10 @@ abstract class wc_onpay_gateway_abstract extends WC_Payment_Gateway {
                 'redirect' => $redirect
             ];
         } catch (InvalidArgumentException $e) {
-            $error = __('Invalid data provided. Unable to create OnPay payment', 'wc-onpay') . ' (' . $e->getMessage() . ')';
+            if (function_exists('wc_get_logger')) {
+                wc_get_logger()->error('OnPay invalid argument: ' . $e->getMessage(), ['source' => 'wc-onpay']);
+            }
+            $error = __('Invalid data provided. Unable to create OnPay payment', 'wc-onpay');
         } catch (WoocommerceOnpay\OnPay\API\Exception\TokenException $e) {
             // Log detailed token error information
             wc_onpay_logger_helper::logTokenProblem('OnPay payment processing failed due to token error', [
@@ -83,7 +86,7 @@ abstract class wc_onpay_gateway_abstract extends WC_Payment_Gateway {
 
         if ($updateMethod) {
             // If we're doing an update of method, manually echo error.
-            echo $error;
+            echo esc_html($error);
             exit;
         }
     

--- a/woocommerce-onpay.php
+++ b/woocommerce-onpay.php
@@ -1113,7 +1113,10 @@ function init_onpay() {
                 try {
                     $transaction = $onpayApi->transaction()->getTransaction($transactionId);
                 } catch (OnPay\API\Exception\ApiException $exception) {
-                    $this->outputString(__('Error: ', 'wc-onpay') . $this->cleanOutput($exception->getMessage()));
+                    if (function_exists('wc_get_logger')) {
+                        wc_get_logger()->error('OnPay API exception: ' . $exception->getMessage(), ['source' => 'wc-onpay']);
+                    }
+                    $this->outputString(__('Error: Unable to retrieve transaction from OnPay', 'wc-onpay'));
                     exit;
                 }
 


### PR DESCRIPTION
Log raw exception messages instead of echoing them to users. Show generic translated strings in their place to prevent server error information disclosure.

Before:
<img width="300" height="150" alt="Screenshot 2026-04-24 at 11 17 49" src="https://github.com/user-attachments/assets/adba5d7c-f513-48c6-b1d4-207f091463e1" />

After:
<img width="299" height="79" alt="Screenshot 2026-04-24 at 11 19 15" src="https://github.com/user-attachments/assets/cb425c8c-9d3f-433f-b1bd-426ad6e356ba" />

