### PR TITLE
DK1ONP1-5872 - repaying a failed order does not register a pay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Show amount in payment window for subscription renewal orders
 
 ## [1.0.52] - 2026-06-09
 - Added auto-cancel option

--- a/classes/abstract-gateway.php
+++ b/classes/abstract-gateway.php
@@ -133,12 +133,10 @@ abstract class wc_onpay_gateway_abstract extends WC_Payment_Gateway {
 
         // Check for subscription presence
         $isSubscription = false;
+        $isSubscriptionRenewal = false;
         if ($this->supports('subscriptions')) { // No need to perform subscription related checks, if methods does not support it.
             $isSubscription = $orderHelper->isOrderSubscription($order);
-            // Enforce method update if order is subscription renewal
-            if (!$updateMethod) { // If not already instructed to update method, find out if we need to
-                $updateMethod = $orderHelper->isOrderSubscriptionEarlyRenewal($order) || $orderHelper->isOrderSubscriptionRenewal($order);
-            }
+            $isSubscriptionRenewal = $orderHelper->isOrderSubscriptionEarlyRenewal($order) || $orderHelper->isOrderSubscriptionRenewal($order);
         }
 
         // We'll need to find out details about the currency, and format the order total amount accordingly
@@ -212,7 +210,8 @@ abstract class wc_onpay_gateway_abstract extends WC_Payment_Gateway {
         // Add parameters to callback URL
         $callbackUrl = WC()->api_request_url('wc_onpay' . '_callback');
         $callbackUrl = add_query_arg('order_key', $order->get_order_key(), $callbackUrl);
-        if ($updateMethod) {
+        // Instruct callback to update payment method on subscription, when changing method or paying a renewal order
+        if ($updateMethod || $isSubscriptionRenewal) {
             $callbackUrl = add_query_arg('update_method', true, $callbackUrl);
         }
 

--- a/woocommerce-onpay.php
+++ b/woocommerce-onpay.php
@@ -330,8 +330,8 @@ function init_onpay() {
                         $subscription->save();
                     }
 
-                    // If we're dealing with an renewal, we need to create a new transaction from the subscription
-                    if ($orderHelper->isOrderSubscriptionRenewal($order) || $orderHelper->isOrderSubscriptionEarlyRenewal($order)) {
+                    // If we're dealing with a renewal and no transaction was created yet, we need to create a new transaction from the subscription
+                    if (null === $onpayTransactionNumber && ($orderHelper->isOrderSubscriptionRenewal($order) || $orderHelper->isOrderSubscriptionEarlyRenewal($order))) {
                         // Fetch surcharge settings
                         $surchargeEnabled = $this->get_option(WC_OnPay::SETTING_ONPAY_SURCHARGE_ENABLE) === 'yes';
                         $surchargeVatRate = 0;
@@ -345,15 +345,21 @@ function init_onpay() {
                         }
 
                         $orderAmount = $currencyHelper->majorToMinor($order->get_total(), $orderCurrency->numeric, '.');
-                        
-                        $onpaySubscription = $this->get_onpay_client()->subscription()->getSubscription($onpayNumber);
-                        $createdTransaction = $this->get_onpay_client()->subscription()->createTransactionFromSubscription(
-                            $onpaySubscription->uuid, 
-                            $orderAmount, 
-                            strval($order->get_order_number()),
-                            $surchargeEnabled,
-                            $surchargeVatRate
-                        );
+
+                        try {
+                            $onpaySubscription = $this->get_onpay_client()->subscription()->getSubscription($onpayNumber);
+                            $createdTransaction = $this->get_onpay_client()->subscription()->createTransactionFromSubscription(
+                                $onpaySubscription->uuid,
+                                $orderAmount,
+                                strval($order->get_order_number()),
+                                $surchargeEnabled,
+                                $surchargeVatRate
+                            );
+                        } catch (OnPay\API\Exception\ApiException $exception) {
+                            // Fail order and stop before order is wrongly completed without a transaction
+                            $order->update_status('failed', __('Creating transaction from subscription in OnPay failed: ', 'wc-onpay') . $exception->getMessage());
+                            $this->json_response('Transaction creation failed', true, 500);
+                        }
 
                         // Set transaction number to the one returned from OnPay authorization
                         $onpayTransactionNumber = $createdTransaction->transactionNumber;


### PR DESCRIPTION
When a subscription renewal payment fails and the customer manually pays the failed order, the OnPay payment window opened without showing an amount.

Renewal orders were treated the same as "change payment method" requests, so `setSubscriptionWithTransaction` was never set. 
The renewal amount was charged server-side in the callback, leaving OnPay with nothing to display in the window.

## Changes

- Renewals now get `setSubscriptionWithTransaction(true)` so the amount shows up in the payment window.
- Callback URL still gets `update_method=1` for renewals, so the old failed subscription is cancelled and the new one linked as before.
- Skip the manual `createTransactionFromSubscription` call when OnPay already returned a transaction number, so we don't charge twice.
- Wrapped the fallback call in try/catch (same as [subscriptionPayment]) so an API error fails the order instead of leaving it pending.


https://github.com/user-attachments/assets/fe23dd64-97fb-4b2a-a04d-2d0d6477a414

